### PR TITLE
Workaround PHP 8.1's $GLOBALS variable restrictions

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -73,7 +73,9 @@ class View
 
     self::$views["$hash_file.php"] = "$view.php";
 
-    $GLOBALS = $params;
+    foreach ($params as $key => $value) {
+      $GLOBALS[$key] = $value;
+    }
 
     if (! File::exists($render_file_path)) {
 


### PR DESCRIPTION
PHP 8.1 doesn't like setting $GLOBAL directly gives the following error,

`Fatal error: $GLOBALS can only be modified using the $GLOBALS[$name] = $value syntax in .../webrium/core/src/View.php on line 76`

This locally makes the site work but it doesn't unset currently set things which I'm not sure if is needed or not so please let me know what will be the direction here.

Thanks