### PR TITLE
refactor(file): remove redundant delete_dir alias

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -364,16 +364,6 @@ class File
         return rmdir($dir);
     }
 
-    /**
-     * Alias for deleteDirectory
-     *
-     * @param string $dir The path to the directory
-     * @return bool True if the directory was successfully deleted, false otherwise
-     */
-    public static function delete_dir(string $dir): bool
-    {
-        return self::deleteDirectory($dir);
-    }
 
     /**
      * Create a directory


### PR DESCRIPTION
Removes the deprecated `delete_dir()` wrapper method from the File class to enforce consistent camelCase naming conventions. All internal references should use `deleteDirectory()` instead.
Close #80