### PR TITLE
docs(route): correct Route::source() docblock

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -43,18 +43,26 @@ class Route
     /**
      * Load route files into the router.
      *
-     * When called with just an array of filenames the files are resolved
-     * from the registered 'routes' directory (backward-compatible default).
-     * Pass a directory alias or an absolute path as the first argument to
-     * load route files from any location.
+     * When called with just an array of filenames, the files are resolved
+     * from the directory registered under the alias 'routes' in
+     * {@see Directory}.
+     *
+     * The optional second argument is the name of any other directory
+     * alias registered in {@see Directory} — NOT a relative or absolute
+     * filesystem path. To load route files from a custom location,
+     * register the alias first and then refer to it by name.
      *
      * Examples:
+     *   // Default: loads from the 'routes' alias.
      *   Route::source(['web.php', 'api.php']);
-     *   Route::source(['shop.php'], 'modules/shop/routes');
-     *   Route::source(['admin.php'], '/var/www/admin/routes');
+     *
+     *   // Custom alias: register first, then load by alias name.
+     *   Directory::set('shop_routes', 'modules/shop/routes');
+     *   Route::source(['shop.php'], 'shop_routes');
      *
      * @param  string[]    $fileNames  Filenames to load.
-     * @param  string|null $directory  Directory alias or absolute path (default: 'routes').
+     * @param  string|null $directory  Name of a directory alias registered in
+     *                                 {@see Directory}. Defaults to 'routes'.
      * @return void
      */
     public static function source(array $fileNames, ?string $directory = null): void


### PR DESCRIPTION
The PHPDoc for Route::source() claimed the second argument could be a directory alias OR an absolute path, and included examples passing a relative path ('modules/shop/routes') and an absolute path ('/var/www/admin/routes'). Neither works: the argument is forwarded to Directory::path(), which returns null for unregistered names, so any unregistered string fails silently.

Update the docblock to state clearly that the argument must be the name of a directory alias registered in Directory, and replace the misleading examples with one that registers an alias first and then loads from it.

No behavior change.