### PR TITLE
feat(directory): register database, migrations and seeders paths

### DIFF
--- a/src/Directory.php
+++ b/src/Directory.php
@@ -626,6 +626,11 @@ class Directory
             'helpers' => 'app/Helpers',
             'services' => 'app/Services',
 
+            // Database directories
+            'database' => 'database',
+            'migrations' => 'database/migrations',
+            'seeders' => 'database/seeders',
+
             // Storage directories
             'storage' => 'storage',
             'storage_app' => 'storage/app',


### PR DESCRIPTION
Add 'database', 'migrations', and 'seeders' entries to Directory::initDefaultStructure(), following Laravel's database/ directory convention. Lays the groundwork for FoxDB migration support in webrium/console without creating the directories eagerly, consistent with the existing lazy structure pattern.